### PR TITLE
chore: replace legacy images

### DIFF
--- a/.deco/blocks/pages-blog-adef0fdb06be.json
+++ b/.deco/blocks/pages-blog-adef0fdb06be.json
@@ -107,8 +107,8 @@
                   "value": "INVESTMENTS"
                 },
                 "image": {
-                  "src": "https://assets.decocache.com/maya/d48c0c70-5157-4d0c-ad10-10878c4f5c1a/sharpi_ai_logo.jpg",
-                  "srcMobile": "https://assets.decocache.com/maya/d48c0c70-5157-4d0c-ad10-10878c4f5c1a/sharpi_ai_logo.jpg"
+                  "src": "https://decoims.com/maya/adc8179f-fb26-487f-ba16-5c10a57a6564/sharpi_ai_logo.jpg",
+                  "srcMobile": "https://decoims.com/maya/adc8179f-fb26-487f-ba16-5c10a57a6564/sharpi_ai_logo.jpg"
                 },
                 "title": "Why We Invested in Sharpi",
                 "callToAction": {
@@ -123,8 +123,8 @@
                   "value": "INVESTMENTS"
                 },
                 "image": {
-                  "src": "https://data.decoassets.com/maya/22cd0cc3-b0c2-4171-915e-9dac3e9f5c8b/WhatsApp-Image-2025-02-21-at-16.53.36.jpeg",
-                  "srcMobile": "https://data.decoassets.com/maya/22cd0cc3-b0c2-4171-915e-9dac3e9f5c8b/WhatsApp-Image-2025-02-21-at-16.53.36.jpeg"
+                  "src": "https://decoims.com/maya/69e124f8-369d-48fc-926c-f3781469ad44/WhatsApp-Image-2025-02-21-at-16.53.36.jpeg",
+                  "srcMobile": "https://decoims.com/maya/69e124f8-369d-48fc-926c-f3781469ad44/WhatsApp-Image-2025-02-21-at-16.53.36.jpeg"
                 },
                 "callToAction": {
                   "href": "https://mayacapital.medium.com/why-we-invested-in-jusfy-48c1d4cfdbab",
@@ -139,8 +139,8 @@
                   "value": "INVESTMENTS"
                 },
                 "image": {
-                  "src": "https://data.decoassets.com/maya/98adf092-7afa-468e-961f-a355c7bf5347/phone-computer-graphic-showing-mobile-phone-lifestyle.jpg",
-                  "srcMobile": "https://data.decoassets.com/maya/98adf092-7afa-468e-961f-a355c7bf5347/phone-computer-graphic-showing-mobile-phone-lifestyle.jpg"
+                  "src": "https://decoims.com/maya/e12948b8-1756-4778-9689-d61bb6930927/phone-computer-graphic-showing-mobile-phone-lifestyle.jpg",
+                  "srcMobile": "https://decoims.com/maya/e12948b8-1756-4778-9689-d61bb6930927/phone-computer-graphic-showing-mobile-phone-lifestyle.jpg"
                 },
                 "title": "Why We Invested in Tempo",
                 "callToAction": {

--- a/.deco/blocks/pages-blog-adef0fdb06be.json
+++ b/.deco/blocks/pages-blog-adef0fdb06be.json
@@ -171,8 +171,8 @@
                   "value": "INVESTMENTS"
                 },
                 "image": {
-                  "src": "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/maya/adc8d7a4-482c-4b25-be8c-f912cea8d20d/IMG_7698.jpeg",
-                  "srcMobile": "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/maya/adc8d7a4-482c-4b25-be8c-f912cea8d20d/IMG_7698.jpeg"
+                  "src": "https://decoims.com/maya/adc8d7a4-482c-4b25-be8c-f912cea8d20d/IMG_7698.jpeg",
+                  "srcMobile": "https://decoims.com/maya/adc8d7a4-482c-4b25-be8c-f912cea8d20d/IMG_7698.jpeg"
                 },
                 "title": "Why did MAYA invest in Stay?",
                 "callToAction": {

--- a/.deco/blocks/pages-portfolio-56c9b407baef.json
+++ b/.deco/blocks/pages-portfolio-56c9b407baef.json
@@ -190,8 +190,8 @@
                 "name": "Avra",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/acbd7ae2-5bbb-427e-ad73-5a8f3dae4dc7/Captura-de-tela-2025-09-16-100408.png",
-                    "desktop": "https://assets.decocache.com/maya/acbd7ae2-5bbb-427e-ad73-5a8f3dae4dc7/Captura-de-tela-2025-09-16-100408.png"
+                    "mobile": "https://decoims.com/maya/de6a0393-e31e-45ce-bd7a-b363c6b4c8c7/Captura-de-tela-2025-09-16-100408.png",
+                    "desktop": "https://decoims.com/maya/de6a0393-e31e-45ce-bd7a-b363c6b4c8c7/Captura-de-tela-2025-09-16-100408.png"
                   },
                   "sector": [
                     {
@@ -259,8 +259,8 @@
                 "name": "Belvo",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/4c03bb13-bf78-46c6-aa28-0e8e7914f5ca/belvo_point-(1).svg",
-                    "desktop": "https://assets.decocache.com/maya/4c03bb13-bf78-46c6-aa28-0e8e7914f5ca/belvo_point-(1).svg"
+                    "mobile": "https://decoims.com/maya/bc470ae8-9cc7-4524-95e7-bbf5c1be7222/belvo_point-(1).svg",
+                    "desktop": "https://decoims.com/maya/bc470ae8-9cc7-4524-95e7-bbf5c1be7222/belvo_point-(1).svg"
                   },
                   "sector": [
                     {
@@ -321,8 +321,8 @@
                 "name": "Deco",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/604c7ca5-ebb8-4ce0-b13d-3ac758084b60/image-removebg-preview-(3).png",
-                    "desktop": "https://assets.decocache.com/maya/604c7ca5-ebb8-4ce0-b13d-3ac758084b60/image-removebg-preview-(3).png"
+                    "mobile": "https://decoims.com/maya/2e2fdc61-cbf1-458b-85f7-2d6444b38d0f/image-removebg-preview-(3).png",
+                    "desktop": "https://decoims.com/maya/2e2fdc61-cbf1-458b-85f7-2d6444b38d0f/image-removebg-preview-(3).png"
                   },
                   "sector": [
                     {
@@ -425,8 +425,8 @@
                 "name": "EmCasa",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/e74e5d67-c24c-4b57-8c09-d7669d1a0b37/images-(1).png",
-                    "desktop": "https://assets.decocache.com/maya/e74e5d67-c24c-4b57-8c09-d7669d1a0b37/images-(1).png"
+                    "mobile": "https://decoims.com/maya/4eb87d13-ccfc-4ce4-8743-f5385110b166/images-(1).png",
+                    "desktop": "https://decoims.com/maya/4eb87d13-ccfc-4ce4-8743-f5385110b166/images-(1).png"
                   },
                   "sector": [
                     {
@@ -452,8 +452,8 @@
                 "name": "Finkargo",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/29176b47-3fce-4fa3-aba6-b12407d59d4e/67237d1867795984e62ccda0_Finkargo-Squared-logo.png",
-                    "desktop": "https://assets.decocache.com/maya/29176b47-3fce-4fa3-aba6-b12407d59d4e/67237d1867795984e62ccda0_Finkargo-Squared-logo.png"
+                    "mobile": "https://decoims.com/maya/b56aa959-5dca-4b2d-80c3-b55256511d1f/67237d1867795984e62ccda0_Finkargo-Squared-logo.png",
+                    "desktop": "https://decoims.com/maya/b56aa959-5dca-4b2d-80c3-b55256511d1f/67237d1867795984e62ccda0_Finkargo-Squared-logo.png"
                   },
                   "sector": [
                     {
@@ -526,8 +526,8 @@
                 "name": "Jota!",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/88dab034-2435-495e-b402-e72ab6d5039b/jota.png",
-                    "desktop": "https://assets.decocache.com/maya/88dab034-2435-495e-b402-e72ab6d5039b/jota.png"
+                    "mobile": "https://decoims.com/maya/5d1ebdb8-1b9e-4f1c-b416-f30a7ddd7366/jota.png",
+                    "desktop": "https://decoims.com/maya/5d1ebdb8-1b9e-4f1c-b416-f30a7ddd7366/jota.png"
                   },
                   "sector": [
                     {
@@ -541,27 +541,27 @@
                   "founders": [
                     {
                       "name": "Davi Holanda",
-                      "image": "https://assets.decocache.com/maya/f56df837-3e17-4b6f-855b-623c2d131e61/jota_logo.jfif"
+                      "image": "https://decoims.com/maya/ee4d0d67-681e-4f40-bb58-3e1ffa574f02/jota_logo.jfif"
                     },
                     {
                       "name": "Vítor Meneguzzi Groterhorst",
-                      "image": "https://assets.decocache.com/maya/f56df837-3e17-4b6f-855b-623c2d131e61/jota_logo.jfif"
+                      "image": "https://decoims.com/maya/ee4d0d67-681e-4f40-bb58-3e1ffa574f02/jota_logo.jfif"
                     },
                     {
                       "name": "Oleg Balev",
-                      "image": "https://assets.decocache.com/maya/f56df837-3e17-4b6f-855b-623c2d131e61/jota_logo.jfif"
+                      "image": "https://decoims.com/maya/ee4d0d67-681e-4f40-bb58-3e1ffa574f02/jota_logo.jfif"
                     },
                     {
                       "name": "Marcelo Leite",
-                      "image": "https://assets.decocache.com/maya/f56df837-3e17-4b6f-855b-623c2d131e61/jota_logo.jfif"
+                      "image": "https://decoims.com/maya/ee4d0d67-681e-4f40-bb58-3e1ffa574f02/jota_logo.jfif"
                     },
                     {
                       "name": "Tiago Guilhon",
-                      "image": "https://assets.decocache.com/maya/f56df837-3e17-4b6f-855b-623c2d131e61/jota_logo.jfif"
+                      "image": "https://decoims.com/maya/ee4d0d67-681e-4f40-bb58-3e1ffa574f02/jota_logo.jfif"
                     },
                     {
                       "name": "Diego Bittencourt ",
-                      "image": "https://assets.decocache.com/maya/f56df837-3e17-4b6f-855b-623c2d131e61/jota_logo.jfif"
+                      "image": "https://decoims.com/maya/ee4d0d67-681e-4f40-bb58-3e1ffa574f02/jota_logo.jfif"
                     }
                   ],
                   "coInvestors": "HOF Capital, BigBets, Alter Global, Bogari  Capital, Norte Ventures",
@@ -573,8 +573,8 @@
                 "name": "Jusfy",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/43bac154-ef9d-4857-a635-cde6d5935d04/logo-jusfy.svg",
-                    "desktop": "https://assets.decocache.com/maya/43bac154-ef9d-4857-a635-cde6d5935d04/logo-jusfy.svg"
+                    "mobile": "https://decoims.com/maya/f557ac65-5309-4fb2-93fe-dacd7f834080/logo-jusfy.svg",
+                    "desktop": "https://decoims.com/maya/f557ac65-5309-4fb2-93fe-dacd7f834080/logo-jusfy.svg"
                   },
                   "sector": [
                     {
@@ -588,7 +588,7 @@
                   "founders": [
                     {
                       "name": "Rafael Saccol Bagolin",
-                      "image": "https://data.decoassets.com/maya/22cd0cc3-b0c2-4171-915e-9dac3e9f5c8b/WhatsApp-Image-2025-02-21-at-16.53.36.jpeg"
+                      "image": "https://decoims.com/maya/69e124f8-369d-48fc-926c-f3781469ad44/WhatsApp-Image-2025-02-21-at-16.53.36.jpeg"
                     }
                   ],
                   "coInvestors": "Saasholic, FJ Labs, The Legal Tech Fund   ",
@@ -600,8 +600,8 @@
                 "name": "Lerian",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/92bf75c6-131a-4dc4-8e1e-54415a8166d2/lerian.png",
-                    "desktop": "https://assets.decocache.com/maya/92bf75c6-131a-4dc4-8e1e-54415a8166d2/lerian.png"
+                    "mobile": "https://decoims.com/maya/344134d7-e18c-41a4-9a17-87cb226ab3b6/lerian.png",
+                    "desktop": "https://decoims.com/maya/344134d7-e18c-41a4-9a17-87cb226ab3b6/lerian.png"
                   },
                   "sector": [
                     {
@@ -615,7 +615,7 @@
                   "founders": [
                     {
                       "name": "Fred Amaral",
-                      "image": "https://assets.decocache.com/maya/bafec18a-f0dc-4a49-a914-ed3ab5283f89/Captura-de-tela-2025-04-01-143846.png"
+                      "image": "https://decoims.com/maya/6adf288e-5e30-46ac-9227-732245eec1a5/Captura-de-tela-2025-04-01-143846.png"
                     }
                   ],
                   "coInvestors": "Saasholic, FJ Labs, The Legal Tech Fund   ",
@@ -797,8 +797,8 @@
                 "name": "Nexa Finance",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/20c521c9-a311-4b67-8f6d-fbe8b830c7da/Captura-de-tela-2025-07-02-141628.png",
-                    "desktop": "https://assets.decocache.com/maya/20c521c9-a311-4b67-8f6d-fbe8b830c7da/Captura-de-tela-2025-07-02-141628.png"
+                    "mobile": "https://decoims.com/maya/337e3e04-cf65-4182-8c2a-9d37df0620b3/Captura-de-tela-2025-07-02-141628.png",
+                    "desktop": "https://decoims.com/maya/337e3e04-cf65-4182-8c2a-9d37df0620b3/Captura-de-tela-2025-07-02-141628.png"
                   },
                   "sector": [
                     {
@@ -812,15 +812,15 @@
                   "founders": [
                     {
                       "name": "Eduardo Furuie",
-                      "image": "https://assets.decocache.com/maya/e3f45ded-a266-4be5-b69a-a76e79b19d38/1730832794944.jpg"
+                      "image": "https://decoims.com/maya/19dfadd4-bccc-40b0-9b6a-2fec460dd3fb/1730832794944.jpg"
                     },
                     {
                       "name": "Bernardo Luca",
-                      "image": "https://assets.decocache.com/maya/dec717a9-af81-4684-855d-d326c2f6474e/1640365649687.jpg"
+                      "image": "https://decoims.com/maya/cd73be2f-8ff5-4e5a-bb03-f0dcfdd3deb5/1640365649687.jpg"
                     },
                     {
                       "name": "Lucas Danicek Borges",
-                      "image": "https://assets.decocache.com/maya/2464c071-bfa8-4f9d-8d6b-a5c4dd3a771c/1731438640267.jpg"
+                      "image": "https://decoims.com/maya/eac667c3-56bb-4d29-861f-c4ca9daf2cb2/1731438640267.jpg"
                     }
                   ],
                   "coInvestors": "Canary, GFC, Grão VC, Softbank",
@@ -925,8 +925,8 @@
                 "name": "Polaxys",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/cbedf5eb-0daa-41f7-ac94-2226b366427f/polaxys.png",
-                    "desktop": "https://assets.decocache.com/maya/cbedf5eb-0daa-41f7-ac94-2226b366427f/polaxys.png"
+                    "mobile": "https://decoims.com/maya/c427bed0-9fcf-42c9-96c2-00856c6ddaa3/polaxys.png",
+                    "desktop": "https://decoims.com/maya/c427bed0-9fcf-42c9-96c2-00856c6ddaa3/polaxys.png"
                   },
                   "sector": [
                     {
@@ -940,11 +940,11 @@
                   "founders": [
                     {
                       "name": "Rafael Martins",
-                      "image": "https://assets.decocache.com/maya/3d0c24cb-8d68-4018-8bf0-36e7705b99e6/1694461663666.jpg"
+                      "image": "https://decoims.com/maya/116799ae-7586-442d-8c6b-9ee513a662b6/1694461663666.jpg"
                     },
                     {
                       "name": "Bernardo Rufino",
-                      "image": "https://assets.decocache.com/maya/17ea2f1e-140d-4327-b6b3-11b8aefdae7d/1736191356213.jpg"
+                      "image": "https://decoims.com/maya/9b5127a8-385a-4524-a8e5-528d82ae0f3c/1736191356213.jpg"
                     }
                   ],
                   "coInvestors": "Propel",
@@ -998,8 +998,8 @@
                 "name": "Start",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/80769046-196c-4d2e-86f0-6c4faa8ca6f3/Captura-de-tela-2025-09-16-101032.png",
-                    "desktop": "https://assets.decocache.com/maya/80769046-196c-4d2e-86f0-6c4faa8ca6f3/Captura-de-tela-2025-09-16-101032.png"
+                    "mobile": "https://decoims.com/maya/deb95145-b2c3-42d8-b175-19f7f4d2baeb/Captura-de-tela-2025-09-16-101032.png",
+                    "desktop": "https://decoims.com/maya/deb95145-b2c3-42d8-b175-19f7f4d2baeb/Captura-de-tela-2025-09-16-101032.png"
                   },
                   "sector": [
                     {
@@ -1099,8 +1099,8 @@
                 "name": "Tempo",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/d6518bd9-0a7c-42d6-9729-68201bae9302/Captura-de-tela-2025-09-16-101148.png",
-                    "desktop": "https://assets.decocache.com/maya/d6518bd9-0a7c-42d6-9729-68201bae9302/Captura-de-tela-2025-09-16-101148.png"
+                    "mobile": "https://decoims.com/maya/5c0cdc68-7f89-464a-bd25-7d019cf74f25/Captura-de-tela-2025-09-16-101148.png",
+                    "desktop": "https://decoims.com/maya/5c0cdc68-7f89-464a-bd25-7d019cf74f25/Captura-de-tela-2025-09-16-101148.png"
                   },
                   "sector": [
                     {
@@ -1200,8 +1200,8 @@
                 "name": "Tivita",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/8209e576-e7f6-4c76-9bf6-954f27bee729/Captura-de-tela-2025-09-16-101244.png",
-                    "desktop": "https://assets.decocache.com/maya/8209e576-e7f6-4c76-9bf6-954f27bee729/Captura-de-tela-2025-09-16-101244.png"
+                    "mobile": "https://decoims.com/maya/b9a6944b-543b-4a7b-a3ea-32e0621eedf4/Captura-de-tela-2025-09-16-101244.png",
+                    "desktop": "https://decoims.com/maya/b9a6944b-543b-4a7b-a3ea-32e0621eedf4/Captura-de-tela-2025-09-16-101244.png"
                   },
                   "sector": [
                     {
@@ -1231,8 +1231,8 @@
                 "name": "Treble.ai",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/6bea2e92-2184-49ad-bf03-390e04b8934a/treble.webp",
-                    "desktop": "https://assets.decocache.com/maya/6bea2e92-2184-49ad-bf03-390e04b8934a/treble.webp"
+                    "mobile": "https://decoims.com/maya/c56f29da-dd07-44a3-8ddf-a32ee35528da/treble.webp",
+                    "desktop": "https://decoims.com/maya/c56f29da-dd07-44a3-8ddf-a32ee35528da/treble.webp"
                   },
                   "sector": [
                     {
@@ -1301,8 +1301,8 @@
                 "name": "Trybe",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/5d093e87-363a-4c88-a01e-6fc8b74aa301/betrybe_logo.jpg",
-                    "desktop": "https://assets.decocache.com/maya/5d093e87-363a-4c88-a01e-6fc8b74aa301/betrybe_logo.jpg"
+                    "mobile": "https://decoims.com/maya/55367402-97c6-4c00-a9a9-7fd296dce51c/betrybe_logo.jpg",
+                    "desktop": "https://decoims.com/maya/55367402-97c6-4c00-a9a9-7fd296dce51c/betrybe_logo.jpg"
                   },
                   "sector": [
                     {
@@ -1445,8 +1445,8 @@
                 "name": "XFX",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/fd118b5f-449e-408e-8fb9-64584f0afe93/Captura-de-tela-2025-07-02-144013.png",
-                    "desktop": "https://assets.decocache.com/maya/fd118b5f-449e-408e-8fb9-64584f0afe93/Captura-de-tela-2025-07-02-144013.png"
+                    "mobile": "https://decoims.com/maya/73c2a27e-8a1a-4794-819d-1cd5bb1cbd38/Captura-de-tela-2025-07-02-144013.png",
+                    "desktop": "https://decoims.com/maya/73c2a27e-8a1a-4794-819d-1cd5bb1cbd38/Captura-de-tela-2025-07-02-144013.png"
                   },
                   "sector": [
                     {
@@ -1460,15 +1460,15 @@
                   "founders": [
                     {
                       "name": "Santiago Alvarado",
-                      "image": "https://assets.decocache.com/maya/8c0f94e8-d277-4d33-9899-020da6889eba/1591764409691.jpg"
+                      "image": "https://decoims.com/maya/4d9e7334-bd9f-449a-8c94-0f77d6cd0f3d/1591764409691.jpg"
                     },
                     {
                       "name": "Alberto Sánchez Tello",
-                      "image": "https://assets.decocache.com/maya/cd777a23-02d5-4ba0-b10c-ca6ac8859748/alberto.jpg"
+                      "image": "https://decoims.com/maya/bc2420d4-f33b-499b-bcf4-84dc53f22fae/alberto.jpg"
                     },
                     {
                       "name": "Jason Losh",
-                      "image": "https://assets.decocache.com/maya/caebf60c-a3d3-48b1-9818-ec764c40b05d/jason-losh.jpg"
+                      "image": "https://decoims.com/maya/de5bf98a-8147-4993-81ba-58adc07c3ad8/jason-losh.jpg"
                     }
                   ],
                   "coInvestors": "Haun Ventures, Castle Island Ventures",
@@ -1511,8 +1511,8 @@
                 "name": "Zubale",
                 "content": {
                   "image": {
-                    "mobile": "https://assets.decocache.com/maya/dfbd80db-5a8e-45e0-a468-b35e681386cd/logo_zubale_2023.png",
-                    "desktop": "https://assets.decocache.com/maya/dfbd80db-5a8e-45e0-a468-b35e681386cd/logo_zubale_2023.png"
+                    "mobile": "https://decoims.com/maya/fcc8e209-7146-4a4a-ae0c-b138f7fa6ccc/logo_zubale_2023.png",
+                    "desktop": "https://decoims.com/maya/fcc8e209-7146-4a4a-ae0c-b138f7fa6ccc/logo_zubale_2023.png"
                   },
                   "sector": [
                     {

--- a/.deco/blocks/pages-portfolio-56c9b407baef.json
+++ b/.deco/blocks/pages-portfolio-56c9b407baef.json
@@ -36,8 +36,8 @@
                 "name": "Alice",
                 "content": {
                   "image": {
-                    "mobile": "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/maya/e0295dba-cbc6-4d85-89ad-8a61bc53096a/Alice-Logo-preto.png",
-                    "desktop": "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/maya/e0295dba-cbc6-4d85-89ad-8a61bc53096a/Alice-Logo-preto.png"
+                    "mobile": "https://decoims.com/maya/e0295dba-cbc6-4d85-89ad-8a61bc53096a/Alice-Logo-preto.png",
+                    "desktop": "https://decoims.com/maya/e0295dba-cbc6-4d85-89ad-8a61bc53096a/Alice-Logo-preto.png"
                   },
                   "sector": [
                     {

--- a/.deco/blocks/pages-team-a37f145075a8.json
+++ b/.deco/blocks/pages-team-a37f145075a8.json
@@ -168,7 +168,7 @@
               {
                 "name": "Letícia Lage Neves",
                 "image": {
-                  "src": "https://assets.decocache.com/maya/7a719faf-0441-4588-8d52-03d6439fe81d/6F92BDE7-0117-4BAB-B161-BB9627E40FEE-(1).jpg"
+                  "src": "https://decoims.com/maya/08ba40a0-a30c-49b9-a1f3-486fb9023360/6F92BDE7-0117-4BAB-B161-BB9627E40FEE-(1).jpg"
                 },
                 "jobPosition": "Investments",
                 "socialAction": {
@@ -205,7 +205,7 @@
               {
                 "name": "Sara Santos",
                 "image": {
-                  "src": "https://assets.decocache.com/maya/0d1f5262-b9ee-451c-b70d-6f2db4b0ac53/IMG_5847-(1).jpg",
+                  "src": "https://decoims.com/maya/fff5128a-ae35-4eab-b3d1-4cc7ef839a5a/IMG_5847-(1).jpg",
                   "alt": "Go To Linkedin "
                 },
                 "jobPosition": "Investments",

--- a/.deco/blocks/site.json
+++ b/.deco/blocks/site.json
@@ -1,7 +1,7 @@
 {
   "seo": {
     "type": "website",
-    "image": "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/maya/55e8ddb1-5814-494e-a04c-3aeabd76d1b1/MAYA_LOGO_CMYK_VERTICAL_DUO-1.jpg",
+    "image": "https://decoims.com/maya/55e8ddb1-5814-494e-a04c-3aeabd76d1b1/MAYA_LOGO_CMYK_VERTICAL_DUO-1.jpg",
     "title": "Maya Capital",
     "jsonLDs": [],
     "canonical": "https://fashion.deco.site",
@@ -9,7 +9,7 @@
     "description": "MAYA Capital is an early-stage fund that supports bold leaders who are catalyzing change in Latin America.",
     "titleTemplate": "%s | MAYA Capital",
     "descriptionTemplate": "%s | MAYA Capital",
-    "favicon": "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/maya/55e8ddb1-5814-494e-a04c-3aeabd76d1b1/MAYA_LOGO_CMYK_VERTICAL_DUO-1.jpg"
+    "favicon": "https://decoims.com/maya/55e8ddb1-5814-494e-a04c-3aeabd76d1b1/MAYA_LOGO_CMYK_VERTICAL_DUO-1.jpg"
   },
   "theme": {
     "__resolveType": "Global Theme"

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -41,7 +41,7 @@ export default defineApp(async (_req, ctx) => {
 
         <link
           rel="icon"
-          href="https://assets.decocache.com/maya/a7bfa47f-25c7-4a6b-aae4-2302ba06a856/FaviconMAYA.png"
+          href="https://decoims.com/maya/4ce6d17f-bd4c-42c8-9880-3270f57da0a5/FaviconMAYA.png"
         />
 
         {/* Local Second Font */}


### PR DESCRIPTION
Migrates all legacy image URLs (decocache, decoassets, supabase, decoazn, s3) to the current decoims.com CDN.

Generated automatically by the legacy image migration script.